### PR TITLE
working better in Windows Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+*.swp

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -1,3 +1,12 @@
+if ENV['OS'] == 'Windows_NT'
+  begin
+    require "win32/open3"
+  rescue Exception => e
+    raise Error, "You need the win32/open3 gem to use Ruby YUI Compreessor in a Windows environment. #{e}"
+  end
+else
+  require "open3"
+end
 require "open3"
 require "stringio"
 

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -7,7 +7,6 @@ if ENV['OS'] == 'Windows_NT'
 else
   require "open3"
 end
-require "open3"
 require "stringio"
 
 module YUI #:nodoc:
@@ -29,6 +28,7 @@ module YUI #:nodoc:
     def initialize(options = {}) #:nodoc:
       @options = self.class.default_options.merge(options)
       @command = [path_to_java, "-jar", path_to_jar_file, *(command_option_for_type + command_options)]
+      @command = @command.flatten.join(' ') if ENV['OS'] == 'Windows_NT'
     end
     
     # Compress a stream or string of code with YUI Compressor. (A stream is


### PR DESCRIPTION
Hi.
At a windows environment we need to use 'win32/open3' instead of 'open3'.
I updated your gem require it and also solved issue #3 when in a windows environment.
All tests passed on my system (Windows 7 x64).
Right now I don't have another machine to test, but it will be good to test if nothing broke for unix systems.

Ps. this is my first pull request... sorry if I made something wrong.
