### PR TITLE
can you pull this change - it is needed so that encoding does not mess up in Ruby 1.9

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -62,6 +62,7 @@ module YUI #:nodoc:
         Open3.popen3(*command) do |stdin, stdout, stderr|
           begin
             transfer(stream, stdin)
+            stdin.binmode
 
             if block_given?
               yield stdout

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -61,8 +61,8 @@ module YUI #:nodoc:
       streamify(stream_or_string) do |stream|
         Open3.popen3(*command) do |stdin, stdout, stderr|
           begin
-            transfer(stream, stdin)
             stdin.binmode
+            transfer(stream, stdin)
 
             if block_given?
               yield stdout


### PR DESCRIPTION
I was getting an invalid ASCII to UTF-8 conversion error without this.  Maybe there is a better way, but this definitely works.
