### PR TITLE
Allow java vm flags to be passed in

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -21,8 +21,9 @@ module YUI #:nodoc:
 
     def initialize(options = {}) #:nodoc:
       @options = self.class.default_options.merge(options)
+      java_opts = @options.delete(:java_opts)
       @command = [path_to_java]
-      @command << java_opts unless java_opts.empty?
+      @command << java_opts if java_opts
       @command += ["-jar", path_to_jar_file, *(command_option_for_type + command_options)]
     end
 
@@ -94,10 +95,6 @@ module YUI #:nodoc:
 
       def path_to_java
         options.delete(:java) || "java"
-      end
-
-      def java_opts
-        options.delete(:java_opts) || ""
       end
 
       def path_to_jar_file

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -21,7 +21,9 @@ module YUI #:nodoc:
 
     def initialize(options = {}) #:nodoc:
       @options = self.class.default_options.merge(options)
-      @command = [path_to_java, "-jar", path_to_jar_file, *(command_option_for_type + command_options)]
+      @command = [path_to_java]
+      @command << java_opts unless java_opts.empty?
+      @command += ["-jar", path_to_jar_file, *(command_option_for_type + command_options)]
     end
 
     # Compress a stream or string of code with YUI Compressor. (A stream is
@@ -92,6 +94,10 @@ module YUI #:nodoc:
 
       def path_to_java
         options.delete(:java) || "java"
+      end
+
+      def java_opts
+        options.delete(:java_opts) || ""
       end
 
       def path_to_jar_file

--- a/yui-compressor.gemspec
+++ b/yui-compressor.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.description = "A Ruby interface to YUI Compressor for minifying JavaScript and CSS assets."
   s.homepage = "http://github.com/sstephenson/ruby-yui-compressor/"
   s.rubyforge_project = "yui"
-  s.has_rdoc = true
   s.authors = ["Sam Stephenson"]
   s.files = Dir["Rakefile", "lib/**/*", "test/**/*"]
   s.test_files = Dir["test/*_test.rb"] unless $SAFE > 0


### PR DESCRIPTION
One of the smaller servers I use yui-compressor on seems to blow up unless I set the -Xmx64M flag. This is just a small commit to allow the initializer to accept <code>:java_opts</code>. So you can do something like:

<code>YUI::JavaScriptCompressor.new(:java_opts => '-Xmx64M')</code>
