### PR TITLE
Raise an exception when the YUI compressor fails due to a JavaScript error

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -5,6 +5,8 @@ module YUI #:nodoc:
   class Compressor
     VERSION = "0.9.4"
 
+    YUI_ERROR_MARKER = '[ERROR]'
+
     class Error < StandardError; end
     class OptionError   < Error; end
     class RuntimeError  < Error; end
@@ -63,6 +65,8 @@ module YUI #:nodoc:
           begin
             stdin.binmode
             transfer(stream, stdin)
+
+            raise if stderr.read.include?(YUI_ERROR_MARKER)
 
             if block_given?
               yield stdout

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -33,6 +33,8 @@ module YUI
         }
       })("hello");
     END_JS
+
+    FIXTURE_ERROR_JS = "var x = {class: 'name'};"
     
     def test_compressor_should_raise_when_instantiated
       assert_raises YUI::Compressor::Error do
@@ -94,6 +96,13 @@ module YUI
     def test_preserve_semicolons_option_should_preserve_semicolons
       @compressor = YUI::JavaScriptCompressor.new(:preserve_semicolons => true)
       assert_equal "var Foo={a:1};Foo.bar=(function(baz){if(false){doSomething();}else{for(var index=0;index<baz.length;index++){doSomething(baz[index]);}}})(\"hello\");", @compressor.compress(FIXTURE_JS)
+    end
+
+    def test_compress_should_raise_on_javascript_syntax_error
+      @compressor = YUI::JavaScriptCompressor.new
+      assert_raise YUI::Compressor::RuntimeError do
+        @compressor.compress(FIXTURE_ERROR_JS)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a fix to the issue I opened last night: https://github.com/sstephenson/ruby-yui-compressor/issues/10. It just texts stderr for any error messages. An alternate solution would be to use IO.popen instead of Open3.popen3 so the subprocesses exit status could be checked properly.
