### PR TITLE
Failing test, revert of stderr-reading feature, and gem version bump to 0.9.6.

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -3,7 +3,7 @@ require "stringio"
 
 module YUI #:nodoc:
   class Compressor
-    VERSION = "0.9.4"
+    VERSION = "0.9.5"
 
     YUI_ERROR_MARKER = '[ERROR]'
 

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -3,9 +3,7 @@ require "stringio"
 
 module YUI #:nodoc:
   class Compressor
-    VERSION = "0.9.5"
-
-    YUI_ERROR_MARKER = '[ERROR]'
+    VERSION = "0.9.6"
 
     class Error < StandardError; end
     class OptionError   < Error; end
@@ -65,8 +63,6 @@ module YUI #:nodoc:
           begin
             stdin.binmode
             transfer(stream, stdin)
-
-            raise if stderr.read.include?(YUI_ERROR_MARKER)
 
             if block_given?
               yield stdout

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -33,8 +33,6 @@ module YUI
         }
       })("hello");
     END_JS
-
-    FIXTURE_ERROR_JS = "var x = {class: 'name'};"
     
     def test_compressor_should_raise_when_instantiated
       assert_raises YUI::Compressor::Error do
@@ -102,13 +100,6 @@ module YUI
     def test_preserve_semicolons_option_should_preserve_semicolons
       @compressor = YUI::JavaScriptCompressor.new(:preserve_semicolons => true)
       assert_equal "var Foo={a:1};Foo.bar=(function(baz){if(false){doSomething();}else{for(var index=0;index<baz.length;index++){doSomething(baz[index]);}}})(\"hello\");", @compressor.compress(FIXTURE_JS)
-    end
-
-    def test_compress_should_raise_on_javascript_syntax_error
-      @compressor = YUI::JavaScriptCompressor.new
-      assert_raise YUI::Compressor::RuntimeError do
-        @compressor.compress(FIXTURE_ERROR_JS)
-      end
     end
   end
 end

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -51,7 +51,14 @@ module YUI
       @compressor = YUI::JavaScriptCompressor.new
       assert_equal "var Foo={a:1};Foo.bar=(function(baz){if(false){doSomething()}else{for(var index=0;index<baz.length;index++){doSomething(baz[index])}}})(\"hello\");", @compressor.compress(FIXTURE_JS)
     end
-        
+
+    def test_large_js_should_be_compressed
+      assert_nothing_raised do
+        @compressor = YUI::JavaScriptCompressor.new
+        @compressor.compress(FIXTURE_JS * 200)
+      end
+    end
+                
     def test_compress_should_raise_when_an_unknown_option_is_specified
       assert_raises YUI::Compressor::OptionError do
         @compressor = YUI::CssCompressor.new(:foo => "bar")
@@ -74,8 +81,7 @@ module YUI
     
     def test_line_break_option_should_insert_line_breaks_in_css
       @compressor = YUI::CssCompressor.new(:line_break => 0)
-      assert_equal "div.warning{display:none}\ndiv.error{background:red;color:white}\n@media screen and (max-device-width:640px){body{font-size:90%}\n}", @compressor.compress(FIXTURE_CSS)
-    
+      assert_equal "div.warning{display:none}\ndiv.error{background:red;color:white}\n@media screen and (max-device-width:640px){body{font-size:90%}\n}", @compressor.compress(FIXTURE_CSS)    
     end
     
     def test_line_break_option_should_insert_line_breaks_in_js

--- a/yui-compressor.gemspec
+++ b/yui-compressor.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "yui-compressor"
-  s.version = "0.9.5"
+  s.version = "0.9.6"
   s.date = "2011-03-29"
   s.summary = "JavaScript and CSS minification library"
   s.email = "sstephenson@gmail.com"


### PR DESCRIPTION
Per https://github.com/sstephenson/ruby-yui-compressor/issues/#issue/12 and https://github.com/documentcloud/jammit/issues#issue/155.
