### PR TITLE
JRuby compatibility

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 Ruby-YUI Compressor provides a Ruby interface to the {YUI Compressor Java library}[http://developer.yahoo.com/yui/compressor/] for minifying JavaScript and CSS assets.
 
-<b>Latest version:</b> 0.9.4 (includes YUI Compressor 2.4.4)
+<b>Latest version:</b> 0.9.6 (includes YUI Compressor 2.4.4)
 
 * {API documentation}[http://yui.rubyforge.org/]
 * {Source code}[http://github.com/sstephenson/ruby-yui-compressor/]

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -66,12 +66,14 @@ module YUI #:nodoc:
       streamify(stream_or_string) do |stream|
         tempfile = Tempfile.new('yui_compress')
         tempfile.write stream.read
-        tempfile.close
+        tempfile.flush
 
         begin
           output = `#{command} #{tempfile.path}`
         rescue Exception
           raise RuntimeError, "compression failed"
+        ensure
+          tempfile.close!
         end
 
         if $?.exitstatus.zero?

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -111,14 +111,6 @@ module YUI #:nodoc:
         end
       end
 
-      def transfer(from_stream, to_stream)
-        while buffer = from_stream.read(4096)
-          to_stream.write(buffer)
-        end
-        from_stream.close
-        to_stream.close
-      end
-
       def command_option_for_type
         ["--type", self.class.compressor_type.to_s]
       end

--- a/yui-compressor.gemspec
+++ b/yui-compressor.gemspec
@@ -11,5 +11,4 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Stephenson"]
   s.files = Dir["Rakefile", "lib/**/*", "test/**/*"]
   s.test_files = Dir["test/*_test.rb"] unless $SAFE > 0
-  s.add_dependency "POpen4", ">= 0.1.4"
 end


### PR DESCRIPTION
 Hey Sam, I would really enjoy a JRuby compatible version of the `yui-compressor` gem ...

Now I do not think invoking the compiler from the same process on JRuby is the way since compilers such as YUI and Closure tend to do a `System.exit` after their done ... but still there's a simple way of doing it "your way" - creating a separate `java -jar` process - without using `POpen4` which does a `fork` and thus it's having a hard-time running on JRuby ...

Tests pass on latest JRuby 1.6 as well as MRI 1.8.7 and 1.9.2 (and should work on Windows as well).
