### PR TITLE
Show exception text

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -77,7 +77,7 @@ module YUI #:nodoc:
             end
 
           rescue Exception => e
-            raise RuntimeError, "compression failed"
+            raise RuntimeError, "compression failed (#{e})"
           end
         end
 


### PR DESCRIPTION
"compression failed" with no further information isn't very useful for fixing.
