### PR TITLE
popen4 can return nil status

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -81,7 +81,7 @@ module YUI #:nodoc:
           end
         end
 
-        if status.exitstatus.zero?
+        if status && status.exitstatus.zero?
           output
         else
           raise RuntimeError, "compression failed"


### PR DESCRIPTION
According to popen4 source code comments:

> On windows executing a non existent command does not raise an error
> (as in unix) so on unix we return nil instead of a status object

It means that when java is not installed on unix 84 line in compressor.rb will throw "undefined method `exitstatus' for nil:NilClass (tested on Ubuntu with no java installed). That's why I've added validation for status presence.
