### PR TITLE
add license information to the gem

### DIFF
--- a/yui-compressor.gemspec
+++ b/yui-compressor.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "yui"
   s.has_rdoc = true
   s.authors = ["Sam Stephenson"]
-  s.files = Dir["Rakefile", "lib/**/*", "test/**/*"]
+  s.files = Dir["README.rdoc", "Rakefile", "lib/**/*", "test/**/*"]
   s.test_files = Dir["test/*_test.rb"] unless $SAFE > 0
   s.add_dependency "POpen4", ">= 0.1.4"
 end

--- a/yui-compressor.gemspec
+++ b/yui-compressor.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.summary = "JavaScript and CSS minification library"
   s.email = "sstephenson@gmail.com"
   s.description = "A Ruby interface to YUI Compressor for minifying JavaScript and CSS assets."
+  s.licenses = ["MIT", "BSD-3-clause", "MPL"]
   s.homepage = "http://github.com/sstephenson/ruby-yui-compressor/"
   s.rubyforge_project = "yui"
   s.has_rdoc = true


### PR DESCRIPTION
README.rdoc contains the license information. Let's include that
file in the gem so that license information is also installed.
