### PR TITLE
Failing early if java is not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - jruby-18mode
+  - jruby-19mode
+  - rbx
+  - ruby-head
+  - jruby-head
+  - ree
+script: rake test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+if RUBY_VERSION >= '1.8.6' && RUBY_VERSION < '1.9.3'
+  gem 'rdoc', '>= 2.4.2'
+end
+

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -123,7 +123,9 @@ module YUI #:nodoc:
       end
 
       def path_to_java
-        options.delete(:java) || "java"
+        (options.delete(:java) || "java").tap do |java_path|
+          raise RuntimeError, "Command \"#{java_path}\" is not installed" if linux? && `which #{java_path}`.chomp.empty?
+        end
       end
 
       def java_opts
@@ -156,6 +158,10 @@ module YUI #:nodoc:
 
       def windows?
         RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+      end
+
+      def linux?
+        RbConfig::CONFIG['host_os'] =~ /linux(-gnu)?/
       end
   end
 

--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -32,7 +32,7 @@ module YUI #:nodoc:
     end
 
     def command #:nodoc:
-      if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+      if windows?
         # Shellwords is only for bourne shells, so windows shells get this
         # extremely remedial escaping
         escaped_cmd = @command.map do |word|
@@ -152,6 +152,10 @@ module YUI #:nodoc:
 
       def command_option_for_line_break(line_break)
         line_break ? ["--line-break", line_break.to_s] : []
+      end
+
+      def windows?
+        RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
       end
   end
 

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -138,5 +138,12 @@ module YUI
         @compressor.compress(FIXTURE_ERROR_JS)
       end
     end
+
+    def test_compressor_should_fail_early_when_java_is_missing
+      error = assert_raise YUI::Compressor::RuntimeError do
+        YUI::JavaScriptCompressor.new(:java => '/path/to/nowhere')
+      end
+      assert_equal "Command \"/path/to/nowhere\" is not installed", error.message
+    end
   end
 end


### PR DESCRIPTION
For #38

I added .travis.yml since @stevecrozz insisted in #38 that this work in all currently supported environments.  Since Travis-CI doesn't support widonws, and can only support Mac OS or Linux on a given branch, I opted to only implement this feature for Linux.  Mac OS and Windows users are no worse off than they were before.
