### PR TITLE
fix NoMethodError: undefined method `zero?' for nil:NilClass

### DIFF
--- a/lib/yui/compressor.rb
+++ b/lib/yui/compressor.rb
@@ -98,7 +98,7 @@ module YUI #:nodoc:
           tempfile.close!
         end
 
-        if $?.exitstatus.zero?
+        if $?.exitstatus && $?.exitstatus.zero?
           output
         else
           # Bourne shells tend to blow up here when the command fails, usually


### PR DESCRIPTION
we had misconfiguration on Rails application on our server that was incorrectly compiling assets.

this was cousing Airbreak to capture non descriptive error 

```
NoMethodError: undefined method `zero?' for nil:NilClass
```

```
File    /gems/yui-compressor-0.12.0/lib/yui/compressor.rb:101
Hostname    c0e5a07008d2
Error type  NoMethodError
Error message   NoMethodError: undefined method `zero?' for nil:NilClass
Where   rake#assets:precompile
```

there is alternative PR version of this here https://github.com/sstephenson/ruby-yui-compressor/pull/46  
